### PR TITLE
used another method to accurately get the valid mail keys

### DIFF
--- a/api/src/cloudflare-api/mailGetHtml.js
+++ b/api/src/cloudflare-api/mailGetHtml.js
@@ -28,7 +28,9 @@ module.exports = async function(url) {
 	};
 
 	try {
-        let [prefix, key, ...remainder] = mailKey.split("-")
+		let prefix = mailKey.slice(0,2)
+		let key = mailKey.slice(3)
+		
         // slice the mailgunApi to include the region
         let apiUrl = "https://api.mailgun.net/v3"
         apiUrl = apiUrl.replace("://", "://"+prefix+".")

--- a/api/src/cloudflare-api/mailGetKey.js
+++ b/api/src/cloudflare-api/mailGetKey.js
@@ -27,7 +27,8 @@ module.exports = async function(url) {
 	};
 
 	try {
-		let [prefix, key, ...remainder] = mailKey.split("-")
+		let prefix = mailKey.slice(0,2)
+		let key = mailKey.slice(3)
 		
         // slice the mailgunApi to include the region
         let apiUrl = "https://api.mailgun.net/v3"


### PR DESCRIPTION
Mailgun's message key contains '-' and the code `mailKey.split('-')` obtained invalid keys. Changed the method to use `.slice()` to obtain the correct prefix and key instead.