### PR TITLE
Fixes to grammar in message list and PSA content

### DIFF
--- a/ui/src/components/mail/message_list.vue
+++ b/ui/src/components/mail/message_list.vue
@@ -4,7 +4,7 @@
           background: #fbc02d4f;
           padding: 0.5em;
       ">
-        <i class="fas fa-exclamation-triangle" style="margin-right:0.5em"></i><a href="https://uilicious.com/blog/psa-inboxkitten-will-be-blocking-no-reply-google/" target="_blank"><b>PSA</b>: Please use inboxkitten, for only testing, or non critical emails. See here for more details.</a>
+        <i class="fas fa-exclamation-triangle" style="margin-right:0.5em"></i><a href="https://uilicious.com/blog/psa-inboxkitten-will-be-blocking-no-reply-google/" target="_blank"><b>PSA</b>: Please only use inboxkitten for testing or non critical emails. See here for more details.</a>
       </div>
       <pulse-loader v-if="refreshing" class="loading"></pulse-loader>
       <div class="table-box" v-if="listOfMessages.length > 0">

--- a/ui/src/components/mail/message_list.vue
+++ b/ui/src/components/mail/message_list.vue
@@ -21,7 +21,7 @@
       </div>
       <div class="no-mails" v-if="listOfMessages.length == 0">
         <p>
-          There for no messages for this kitten :(<br/><br/>
+          There are no messages for this kitten :(<br/><br/>
           Press on the 'Refresh' button if you want to overwork the kittens...
         </p>
         <button class="refresh-button" @click="refreshList" v-if="!refreshing">Refresh</button>

--- a/ui/src/landingpage.vue
+++ b/ui/src/landingpage.vue
@@ -40,7 +40,7 @@
 				<div class="pure-u-1-1">
 						<section class="p-1">
 						<h3>
-							<i class="fas fa-exclamation-triangle"></i> PSA: Please use inboxkitten, for only testing, or non critical emails.
+							<i class="fas fa-exclamation-triangle"></i> PSA: Please only use inboxkitten for testing or non critical emails.
 						</h3>
 						<p><a href="https://uilicious.com/blog/psa-inboxkitten-will-be-blocking-no-reply-google/" target="_blank">We block "no-reply@google" to prevent abuse on our platform, see more details on our blog post (here)</a></p>
 					</section>

--- a/ui/uilicious-test/inboxkitten.test.js
+++ b/ui/uilicious-test/inboxkitten.test.js
@@ -21,7 +21,7 @@ I.fill("email", SAMPLE.id(22));
 I.click("Get Mail Nyow!");
 
 // Check that its empty
-I.see("There for no messages for this kitten :(");
+I.see("There are no messages for this kitten :(");
 
 //
 // Testing for regular email


### PR DESCRIPTION
In the message list, "There for no messages ... " corrected to "There are no messages ... "

![image](https://user-images.githubusercontent.com/1331877/143782717-374f8fa9-efa8-4609-9253-4d1758681c04.png)

In the PSA, "Please use inboxkitten, only for testing ..." to "Please only use inboxkitten for testing ..."

![image](https://user-images.githubusercontent.com/1331877/143782736-56307073-22d2-4bd0-bb3f-ac0db13ebc11.png)
